### PR TITLE
SD-1808 Support watching with flags to limit inotify noise/queue size

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,7 @@ package fsnotify_test
 import (
 	"log"
 
-	"github.com/go-fsnotify/fsnotify"
+	"github.com/scalingdata/fsnotify-v1"
 )
 
 func ExampleNewWatcher() {

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -28,6 +28,8 @@ const (
 	Remove
 	Rename
 	Chmod
+
+	AllOps = Create | Write | Remove | Rename | Chmod
 )
 
 // String returns a string representation of the event in the form

--- a/kqueue.go
+++ b/kqueue.go
@@ -91,6 +91,11 @@ func (w *Watcher) Close() error {
 
 // Add starts watching the named file or directory (non-recursively).
 func (w *Watcher) Add(name string) error {
+	return w.AddFlags(name, AllOps)
+}
+
+/* TODO: actually propagate flags to kqueue */
+func (w *Watcher) AddFlags(name string, flags Op) error {
 	w.mu.Lock()
 	w.externalWatches[name] = true
 	w.mu.Unlock()

--- a/windows.go
+++ b/windows.go
@@ -65,6 +65,11 @@ func (w *Watcher) Close() error {
 
 // Add starts watching the named file or directory (non-recursively).
 func (w *Watcher) Add(name string) error {
+	return w.AddFlags(name, AllOps)
+}
+
+// TODO: propagate flags to syscall
+func (w *Watcher) AddFlags(name string, flags Op) error {
 	if w.isClosed {
 		return errors.New("watcher already closed")
 	}


### PR DESCRIPTION
Bring back WatchFlags to reduce the risk of inotify queue overflowing. Linux only for now, other platforms still send all events - basically, flags are advisory and don't guarantee events will be filtered. 
