### PR TITLE
ROCANA-10529: Event struct includes Discovered attribute

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -14,8 +14,9 @@ import (
 
 // Event represents a single file system notification.
 type Event struct {
-	Name string // Relative path to the file or directory.
-	Op   Op     // File operation that triggered the event.
+	Name       string // Relative path to the file or directory.
+	Op         Op     // File operation that triggered the event.
+	Discovered bool   // Indicates event was discovered via means other than filesystem notification (e.g. filesystem walk)
 }
 
 // Op describes a set of file operations.


### PR DESCRIPTION
Adds a `Discovered` attribute to the `Event` struct. The attribute isn't used by fsnotify - its used by follow-on programs that want to generate events via filesystem walks or other mechanisms, and want to distinguish between events generated by active events vs files that are discovered by some other means.

In fsnotify, all generated events will have `Discovered` set to false. Follow-on programs can choose to set `Discovered` to true or leave as false, dependent on their use case.