### PR TITLE
ROCANA-10822: fsnotify provides IsDir flag

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -17,6 +17,7 @@ type Event struct {
 	Name       string // Relative path to the file or directory.
 	Op         Op     // File operation that triggered the event.
 	Discovered bool   // Indicates event was discovered via means other than filesystem notification (e.g. filesystem walk)
+	IsDir      bool   // Indicates the path is a directory. Currently supported on Linux only.
 }
 
 // Op describes a set of file operations.

--- a/inotify.go
+++ b/inotify.go
@@ -296,5 +296,8 @@ func newEvent(name string, mask uint32) Event {
 	if mask&syscall.IN_Q_OVERFLOW == syscall.IN_Q_OVERFLOW {
 		e.Op |= Overflow
 	}
+	if mask&syscall.IN_ISDIR == syscall.IN_ISDIR {
+		e.IsDir = true
+	}
 	return e
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -500,6 +500,13 @@ func TestFsnotifySubDir(t *testing.T) {
 			} else {
 				t.Logf("unexpected event received: %s", event)
 			}
+
+			// Confirm IsDir flag is set appropriately on supported platforms
+			if event.Name == filepath.Clean(testSubDir) && runtime.GOOS == "linux" {
+				if event.IsDir == false {
+					t.Fatalf("expected %s to be marked as directory", event)
+				}
+			}
 		}
 		done <- true
 	}()


### PR DESCRIPTION
Adds an `IsDir` flag to the `Event` struct, so that we can tell if an event is from a directory on Linux without having to perform a `stat`. Other platforms might be included in the future, but Linux is the most important at the moment.